### PR TITLE
Adds text as value type to support larger amount of text

### DIFF
--- a/App_Plugins/MediumEditor/package.manifest
+++ b/App_Plugins/MediumEditor/package.manifest
@@ -6,7 +6,8 @@
 			icon: "icon-font",
 			group: "Rich Content",
 			editor: {
-				view: "~/App_Plugins/MediumEditor/index.html"
+				view: "~/App_Plugins/MediumEditor/index.html",
+				valueType: "TEXT"
 			},
 			prevalues: {
 				fields: [


### PR DESCRIPTION
As the default valuetype in Umbraco is "string" and thus is saved in the database in an nvarchar field, you'll get an error if entering more than a couple of lines of text.

This PR will change default behavior to store in a blob field, thus removing any limitation. Be aware that this only works for new configurations of the PropertyEditor - existing ones will have the old database field type (nvarchar).